### PR TITLE
Fix bug in subscribe endpoint

### DIFF
--- a/api/freshapi.php
+++ b/api/freshapi.php
@@ -612,7 +612,7 @@ final class FreshGReaderAPI extends API {
 				switch ($action) {
 					case 'subscribe':
 						if ($feedId == 0) {
-							$subscribeResponse = self::quickadd($url, $session_id, $category_id);
+							$subscribeResponse = self::quickadd($streamUrl, $session_id, $category_id);
 							if (!$subscribeResponse) {
 								self::badRequest();
 							}


### PR DESCRIPTION
When using a reader that tries to add a new feed using the FreshGReaderAPI:quickadd() function, and exception is thrown:

`Argument #1 ($url) must be of type string, null given, called in /var/www/html/tt-rss/plugins.local/freshapi/api/freshapi.php on line 615`

This is because that function is trying to use `$url` instead of `$streamUrl`. This PR changes that function call to properly pass `$streamUrl`, thereby allowing subscriptions via that endpoint.